### PR TITLE
moved to ./dist

### DIFF
--- a/electron/tsconfig.json
+++ b/electron/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../src/frontends/electron/tsconfig.json",
   "include": ["../src/frontends/electron/**/*"],
-  "exclude": ["../dist-electron"]
+  "exclude": ["../src/frontends/electron/dist"]
 }

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
     "src/core",
     "src/frontends/*"
   ],
-  "main": "dist-electron/main.js",
+  "main": "src/frontends/electron/dist/main.js",
   "scripts": {
     "build": "pnpm -r run build",
     "dev:app": "pnpm --filter @aspire-pipeline-viewer/electron dev",
-    "clean": "rimraf node_modules dist dist-electron .pnpm-store playwright-report test-results || true",
+    "clean": "rimraf node_modules dist src/frontends/electron/dist .pnpm-store playwright-report test-results || true",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,md}\"",
     "lint": "eslint \"src/**/*.{ts,tsx}\" --max-warnings=0",
     "test": "pnpm -r test",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,13 +121,13 @@ importers:
       '@aspire-pipeline-viewer/core':
         specifier: workspace:*
         version: link:../../core
-      electron:
-        specifier: ^39.2.7
-        version: 39.2.7
     devDependencies:
       '@types/node':
         specifier: ^22.10.5
         version: 22.19.3
+      electron:
+        specifier: ^39.2.7
+        version: 39.2.7
       typescript:
         specifier: ^5.9.3
         version: 5.9.3

--- a/src/frontends/electron/package.json
+++ b/src/frontends/electron/package.json
@@ -1,11 +1,13 @@
 {
   "name": "@aspire-pipeline-viewer/electron",
   "version": "0.0.0",
+  "description": "Visual DAG viewer for Aspire pipelines - Desktop App",
+  "author": "tjwald@gmail.com",
   "private": true,
-  "main": "../../../dist-electron/main.js",
+  "main": "./dist/main.js",
   "scripts": {
-    "clean": "rimraf ../../../dist-electron",
-    "dev": "concurrently \"pnpm dev:renderer\" \"wait-on http://localhost:5174 && pnpm build:electron && electron ../../../\"",
+    "clean": "rimraf ./dist",
+    "dev": "concurrently \"pnpm dev:renderer\" \"wait-on http://localhost:5174 && pnpm build:electron && electron .\"",
     "dev:renderer": "vite --config vite.config.ts",
     "build": "pnpm clean && pnpm build:renderer && pnpm build:electron",
     "build:electron": "tsc -p tsconfig.json",
@@ -16,10 +18,10 @@
     "test": "pnpm test:unit && pnpm test:e2e"
   },
   "dependencies": {
-    "@aspire-pipeline-viewer/core": "workspace:*",
-    "electron": "^39.2.7"
+    "@aspire-pipeline-viewer/core": "workspace:*"
   },
   "devDependencies": {
+    "electron": "^39.2.7",
     "@types/node": "^22.10.5",
     "typescript": "^5.9.3"
   }

--- a/src/frontends/electron/tsconfig.json
+++ b/src/frontends/electron/tsconfig.json
@@ -10,9 +10,9 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "strict": true,
-    "outDir": "../../../dist-electron",
+    "outDir": "./dist",
     "rootDir": "./"
   },
   "include": ["main.ts", "preload.ts"],
-  "exclude": ["renderer", "../../../dist-electron"]
+  "exclude": ["renderer", "./dist"]
 }

--- a/src/frontends/electron/vite.config.ts
+++ b/src/frontends/electron/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
     strictPort: true,
   },
   build: {
-    outDir: path.resolve(__dirname, '../../../dist-electron/renderer'),
+    outDir: path.resolve(__dirname, './dist/renderer'),
     emptyOutDir: true,
   },
   resolve: {

--- a/tests/frontends/electron/launch-utils.ts
+++ b/tests/frontends/electron/launch-utils.ts
@@ -14,7 +14,7 @@ export async function launchElectronApp(options?: {
   additionalEnv?: Record<string, string>
 }): Promise<ElectronApplication> {
 
-  const mainPath = path.join(process.cwd(), 'dist-electron/main.js')
+  const mainPath = path.join(process.cwd(), 'src/frontends/electron/dist/main.js')
   // Build args with CI sandbox handling
   const args = [mainPath]
   if (process.env.CI || process.env.GITHUB_ACTIONS) {


### PR DESCRIPTION
Simplified electron build:
* removed need for electron-dist in the root of the project
* moved everything to look at /dist in the electron frontend.
